### PR TITLE
Switch signer implementation from GPG to BouncyCastle.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,12 @@ jobs:
         server-id: maven-central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
-        gpg-passphrase:  MAVEN_GPG_PASSPHRASE
-        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
     - name: Publish to the Maven Central Repository
       run: mvn --batch-mode --activate-profiles maven-central deploy
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        MAVEN_GPG_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        MAVEN_GPG_KEY_FINGERPRINT: ${{ vars.MAVEN_GPG_KEY_FINGERPRINT }}

--- a/pom.xml
+++ b/pom.xml
@@ -114,10 +114,8 @@
               <artifactId>maven-gpg-plugin</artifactId>
               <version>${maven.plugin.gpg.version}</version>
               <configuration>
-                <gpgArguments>
-                  <arg>--pinentry-mode</arg>
-                  <arg>loopback</arg>
-                </gpgArguments>
+                <bestPractices>true</bestPractices>
+                <signer>bc</signer>
               </configuration>
               <executions>
                 <execution>


### PR DESCRIPTION
This PR switches the default signer implementation in the `maven-gpg-plugin` from `gpg` (GnuPG) to `bc` (BouncyCastle).

It also allows for explicitly specifying the signing key fingerprint in the case of a GPG key with multiple UIDs.